### PR TITLE
Minor Fix In Iterators VecDeque Example

### DIFF
--- a/content/blog/2015-05-02-a-journey-into-iterators/index.md
+++ b/content/blog/2015-05-02-a-journey-into-iterators/index.md
@@ -117,7 +117,7 @@ Don't get hung up thinking that `[1, 2, 3]` and it's ilk are the only things you
 Many data structures support this style, we can use things like Vectors and VecDeques as well! Look for things that implement [`iter()`](http://doc.rust-lang.org/std/?search=iter%28%29).
 
 ```rust
-std::collections::VecDeque;
+use std::collections::VecDeque;
 
 fn main() {
     // Create a Vector of values.


### PR DESCRIPTION
This PR makes the change of adding "`use`" to the `std::collections::VecDeque` import (located in `content/blog/2015-05-02-a-journey-into-iterators/index.md`) so that the code compiles fine.

Previously since the use was not included the compile would fail with an error:

```
error: expected one of `!` or `::`, found `;`
 --> src/main.rs:1:27
  |
1 | std::collections::VecDeque;
  |                           ^ expected one of `!` or `::`
```

Reference: [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=8122d7aa95fe59c12725de39b62597d6)

With the fix now the VecDeque compiles & runs fine:

```
Standard Error

   Compiling playground v0.0.1 (/playground)
    Finished dev [unoptimized + debuginfo] target(s) in 1.06s
     Running `target/debug/playground`

Standard Output

[2, 4, 6]
```

Refrence: [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=45ba864068598fce65d2de473f552d3d)
