### PR TITLE
rust-state-machine-pattern typo fix

### DIFF
--- a/content/blog/2016-10-12-rust-state-machine-pattern/index.md
+++ b/content/blog/2016-10-12-rust-state-machine-pattern/index.md
@@ -127,7 +127,7 @@ impl StateMachine {
             // Only Waiting -> Filling is valid.
             State::Waiting { .. } => State::Filling { rate: 1 },
             // The rest should fail.
-            _ => panic!("Invalid state tranistion!"),
+            _ => panic!("Invalid state transition!"),
         }
     }
     // ...


### PR DESCRIPTION
thanks for the great blog post :)

this changes 'tranistion' to 'transition'